### PR TITLE
feature: ツイート作成機能の実装

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -44,6 +44,16 @@ model TokenBlacklist {
   @@index([expiresAt])
 }
 
+model Tweet {
+  id        Int      @id @default(autoincrement())
+  content   String
+  userId    Int
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("tweets")
+}
+
 enum Role {
   USER
   ADMIN

--- a/api/src/controllers/tweetController.test.ts
+++ b/api/src/controllers/tweetController.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTweet } from "./tweetController.js";
+import * as tweetService from "../services/tweetService.js";
+import { TweetErrorType } from "../utils/errors.js";
+
+vi.mock("../services/tweetService.js");
+
+describe("tweetController", () => {
+  describe("createTweet", () => {
+    it("should validate request body", async () => {
+      // Arrange
+      const mockContext = {
+        req: {
+          json: vi.fn().mockResolvedValue({}),
+        },
+        json: vi.fn().mockReturnValue("json response"),
+      } as any;
+
+      // Act
+      const response = await createTweet(mockContext);
+
+      // Assert
+      expect(mockContext.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: "Validation error",
+        }),
+        400
+      );
+    });
+
+    it("should check authentication", async () => {
+      // Arrange
+      const mockContext = {
+        req: {
+          json: vi.fn().mockResolvedValue({ content: "Valid content" }),
+        },
+        get: vi.fn().mockReturnValue(null),
+        json: vi.fn().mockReturnValue("json response"),
+      } as any;
+
+      // Act
+      const response = await createTweet(mockContext);
+
+      // Assert
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "認証情報が不足しています" },
+        401
+      );
+    });
+
+    it("should create tweet when validation passes", async () => {
+      // Arrange
+      const mockTweet = {
+        id: 1,
+        content: "Valid content",
+        userId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const mockContext = {
+        req: {
+          json: vi.fn().mockResolvedValue({ content: "Valid content" }),
+        },
+        get: vi.fn().mockReturnValue({ userId: 1 }),
+        json: vi.fn().mockReturnValue("json response"),
+      } as any;
+      vi.spyOn(tweetService, "createTweet").mockResolvedValue({
+        ok: true,
+        value: mockTweet,
+      });
+
+      // Act
+      const response = await createTweet(mockContext);
+
+      // Assert
+      expect(tweetService.createTweet).toHaveBeenCalledWith(
+        {
+          content: "Valid content",
+          userId: 1,
+        },
+        expect.anything()
+      );
+      expect(mockContext.json).toHaveBeenCalledWith(mockTweet, 201);
+    });
+
+    it("should handle service errors", async () => {
+      // Arrange
+      const mockContext = {
+        req: {
+          json: vi.fn().mockResolvedValue({ content: "Valid content" }),
+        },
+        get: vi.fn().mockReturnValue({ userId: 1 }),
+        json: vi.fn().mockReturnValue("json response"),
+      } as any;
+      vi.spyOn(tweetService, "createTweet").mockResolvedValue({
+        ok: false,
+        error: {
+          type: TweetErrorType.INVALID_TWEET_DATA,
+          message: "Invalid tweet data",
+        },
+      });
+
+      // Act
+      const response = await createTweet(mockContext);
+
+      // Assert
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Invalid tweet data" },
+        400
+      );
+    });
+  });
+});

--- a/api/src/controllers/tweetController.test.ts
+++ b/api/src/controllers/tweetController.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTweet } from "./tweetController.js";
-import * as tweetService from "../services/tweetService.js";
-import { TweetErrorType } from "../utils/errors.js";
+import * as tweetService from "../services/tweetService.ts";
+import { TweetErrorType } from "../utils/errors.ts";
+import { createTweet } from "./tweetController.ts";
 
-vi.mock("../services/tweetService.js");
+vi.mock("../services/tweetService.ts");
 
 describe("tweetController", () => {
   describe("createTweet", () => {
@@ -24,7 +24,7 @@ describe("tweetController", () => {
         expect.objectContaining({
           error: "Validation error",
         }),
-        400
+        400,
       );
     });
 
@@ -44,7 +44,7 @@ describe("tweetController", () => {
       // Assert
       expect(mockContext.json).toHaveBeenCalledWith(
         { error: "認証情報が不足しています" },
-        401
+        401,
       );
     });
 
@@ -78,7 +78,7 @@ describe("tweetController", () => {
           content: "Valid content",
           userId: 1,
         },
-        expect.anything()
+        expect.anything(),
       );
       expect(mockContext.json).toHaveBeenCalledWith(mockTweet, 201);
     });
@@ -106,7 +106,7 @@ describe("tweetController", () => {
       // Assert
       expect(mockContext.json).toHaveBeenCalledWith(
         { error: "Invalid tweet data" },
-        400
+        400,
       );
     });
   });

--- a/api/src/controllers/tweetController.ts
+++ b/api/src/controllers/tweetController.ts
@@ -48,7 +48,7 @@ export const createTweet = async (c: Context) => {
       content: data.content,
       userId: jwtPayload.userId,
     },
-    prisma
+    prisma,
   );
 
   if (!result.ok) {

--- a/api/src/controllers/tweetController.ts
+++ b/api/src/controllers/tweetController.ts
@@ -1,0 +1,68 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import prisma from "../lib/prisma.js";
+import { createTweet as createTweetService } from "../services/tweetService.js";
+import { TweetErrorType } from "../utils/errors.js";
+
+export const tweetCreateSchema = z.object({
+  content: z.string().min(1).max(280),
+});
+
+export const createTweet = async (c: Context) => {
+  // Get JSON data from request body
+  let data;
+
+  try {
+    data = await c.req.json();
+
+    // Validation
+    const validationResult = tweetCreateSchema.safeParse(data);
+    if (!validationResult.success) {
+      return c.json(
+        {
+          error: "Validation error",
+          details: validationResult.error.format(),
+        },
+        400,
+      );
+    }
+  } catch (error) {
+    return c.json(
+      {
+        error: "Invalid JSON",
+        message: "Request body must be a valid JSON",
+      },
+      400,
+    );
+  }
+
+  // Get user ID from JWT payload set by authentication middleware
+  const jwtPayload = c.get("jwtPayload");
+  if (!jwtPayload || !jwtPayload.userId) {
+    return c.json({ error: "認証情報が不足しています" }, 401);
+  }
+
+  // Create tweet
+  const result = await createTweetService(
+    {
+      content: data.content,
+      userId: jwtPayload.userId,
+    },
+    prisma
+  );
+
+  if (!result.ok) {
+    switch (result.error.type) {
+      case TweetErrorType.INVALID_TWEET_DATA:
+        return c.json({ error: result.error.message }, 400);
+      case TweetErrorType.TWEET_CREATION_FAILED:
+        return c.json({ error: result.error.message }, 500);
+      case TweetErrorType.UNAUTHORIZED_ACTION:
+        return c.json({ error: result.error.message }, 403);
+      default:
+        return c.json({ error: "Internal server error" }, 500);
+    }
+  }
+
+  return c.json(result.value, 201);
+};

--- a/api/src/domain/tweet/tweetRepository.test.ts
+++ b/api/src/domain/tweet/tweetRepository.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTweet } from "./tweetRepository.js";
+
+describe("tweetRepository", () => {
+  describe("createTweet", () => {
+    it("should create a tweet successfully", async () => {
+      // Arrange
+      const mockPrisma = {
+        tweet: {
+          create: vi.fn().mockResolvedValue({
+            id: 1,
+            content: "Test tweet",
+            userId: 1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        },
+      };
+
+      // Act
+      const result = await createTweet(
+        { content: "Test tweet", userId: 1 },
+        mockPrisma as any
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(result.value).toHaveProperty("id", 1);
+      expect(result.value).toHaveProperty("content", "Test tweet");
+      expect(result.value).toHaveProperty("userId", 1);
+      expect(mockPrisma.tweet.create).toHaveBeenCalledWith({
+        data: {
+          content: "Test tweet",
+          userId: 1,
+        },
+      });
+    });
+
+    it("should return error when tweet creation fails", async () => {
+      // Arrange
+      const mockError = new Error("Database error");
+      const mockPrisma = {
+        tweet: {
+          create: vi.fn().mockRejectedValue(mockError),
+        },
+      };
+
+      // Act
+      const result = await createTweet(
+        { content: "Test tweet", userId: 1 },
+        mockPrisma as any
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe(mockError);
+    });
+  });
+});

--- a/api/src/domain/tweet/tweetRepository.test.ts
+++ b/api/src/domain/tweet/tweetRepository.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTweet } from "./tweetRepository.js";
+import { createTweet } from "./tweetRepository.ts";
 
 describe("tweetRepository", () => {
   describe("createTweet", () => {
@@ -20,14 +20,16 @@ describe("tweetRepository", () => {
       // Act
       const result = await createTweet(
         { content: "Test tweet", userId: 1 },
-        mockPrisma as any
+        mockPrisma as any,
       );
 
       // Assert
       expect(result.ok).toBe(true);
-      expect(result.value).toHaveProperty("id", 1);
-      expect(result.value).toHaveProperty("content", "Test tweet");
-      expect(result.value).toHaveProperty("userId", 1);
+      if (result.ok) {
+        expect(result.value).toHaveProperty("id", 1);
+        expect(result.value).toHaveProperty("content", "Test tweet");
+        expect(result.value).toHaveProperty("userId", 1);
+      }
       expect(mockPrisma.tweet.create).toHaveBeenCalledWith({
         data: {
           content: "Test tweet",
@@ -48,12 +50,14 @@ describe("tweetRepository", () => {
       // Act
       const result = await createTweet(
         { content: "Test tweet", userId: 1 },
-        mockPrisma as any
+        mockPrisma as any,
       );
 
       // Assert
       expect(result.ok).toBe(false);
-      expect(result.error).toBe(mockError);
+      if (!result.ok) {
+        expect(result.error).toBe(mockError);
+      }
     });
   });
 });

--- a/api/src/domain/tweet/tweetRepository.ts
+++ b/api/src/domain/tweet/tweetRepository.ts
@@ -1,10 +1,10 @@
-import { PrismaClient } from "@prisma/client";
-import type { Result } from "../../utils/result.js";
+import type { PrismaClient } from "@prisma/client";
 import type { TweetCreateInput, TweetResponse } from "../../types/index.js";
+import type { Result } from "../../utils/result.js";
 
 export const createTweet = async (
   data: TweetCreateInput,
-  prisma: PrismaClient
+  prisma: PrismaClient,
 ): Promise<Result<TweetResponse, Error>> => {
   try {
     const tweet = await prisma.tweet.create({

--- a/api/src/domain/tweet/tweetRepository.ts
+++ b/api/src/domain/tweet/tweetRepository.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@prisma/client";
+import type { Result } from "../../utils/result.js";
+import type { TweetCreateInput, TweetResponse } from "../../types/index.js";
+
+export const createTweet = async (
+  data: TweetCreateInput,
+  prisma: PrismaClient
+): Promise<Result<TweetResponse, Error>> => {
+  try {
+    const tweet = await prisma.tweet.create({
+      data: {
+        content: data.content,
+        userId: data.userId,
+      },
+    });
+    return { ok: true, value: tweet };
+  } catch (error) {
+    return { ok: false, error: error as Error };
+  }
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,12 +2,14 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import authRouter from "./routes/auth.js";
 import usersRouter from "./routes/users.js";
+import tweetsRouter from "./routes/tweets.js";
 
 const app = new Hono();
 
 // ルートの設定
 app.route("/api/users", usersRouter);
 app.route("/api/auth", authRouter);
+app.route("/api/tweets", tweetsRouter);
 
 app.get("/", (c) => {
   return c.text("Hello Hono!");

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import authRouter from "./routes/auth.js";
-import usersRouter from "./routes/users.js";
 import tweetsRouter from "./routes/tweets.js";
+import usersRouter from "./routes/users.js";
 
 const app = new Hono();
 

--- a/api/src/routes/tweets.ts
+++ b/api/src/routes/tweets.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+import { createTweet } from "../controllers/tweetController.js";
+import { authenticate } from "../middleware/authMiddleware.js";
+
+const tweetsRouter = new Hono();
+
+// Tweet creation endpoint (requires authentication)
+tweetsRouter.post("/", authenticate, createTweet);
+
+export default tweetsRouter;

--- a/api/src/services/tweetService.test.ts
+++ b/api/src/services/tweetService.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTweet } from "./tweetService.js";
+import * as tweetRepository from "../domain/tweet/tweetRepository.js";
+import { TweetErrorType } from "../utils/errors.js";
+
+vi.mock("../domain/tweet/tweetRepository.js");
+
+describe("tweetService", () => {
+  describe("createTweet", () => {
+    it("should validate tweet content length", async () => {
+      // Arrange
+      const mockPrisma = {} as any;
+      const emptyContent = "";
+      const tooLongContent = "a".repeat(281);
+
+      // Act
+      const emptyResult = await createTweet(
+        { content: emptyContent, userId: 1 },
+        mockPrisma
+      );
+      const tooLongResult = await createTweet(
+        { content: tooLongContent, userId: 1 },
+        mockPrisma
+      );
+
+      // Assert
+      expect(emptyResult.ok).toBe(false);
+      expect(emptyResult.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      expect(tooLongResult.ok).toBe(false);
+      expect(tooLongResult.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+    });
+
+    it("should check if user exists", async () => {
+      // Arrange
+      const mockPrisma = {
+        user: {
+          findUnique: vi.fn().mockResolvedValue(null),
+        },
+      } as any;
+
+      // Act
+      const result = await createTweet(
+        { content: "Valid content", userId: 999 },
+        mockPrisma
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      expect(result.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 999 },
+      });
+    });
+
+    it("should create tweet when validation passes", async () => {
+      // Arrange
+      const mockPrisma = {
+        user: {
+          findUnique: vi.fn().mockResolvedValue({ id: 1 }),
+        },
+      } as any;
+      const mockTweet = {
+        id: 1,
+        content: "Valid content",
+        userId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      vi.spyOn(tweetRepository, "createTweet").mockResolvedValue({
+        ok: true,
+        value: mockTweet,
+      });
+
+      // Act
+      const result = await createTweet(
+        { content: "Valid content", userId: 1 },
+        mockPrisma
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(result.value).toEqual(mockTweet);
+      expect(tweetRepository.createTweet).toHaveBeenCalledWith(
+        { content: "Valid content", userId: 1 },
+        mockPrisma
+      );
+    });
+
+    it("should handle repository errors", async () => {
+      // Arrange
+      const mockPrisma = {
+        user: {
+          findUnique: vi.fn().mockResolvedValue({ id: 1 }),
+        },
+      } as any;
+      vi.spyOn(tweetRepository, "createTweet").mockResolvedValue({
+        ok: false,
+        error: new Error("Repository error"),
+      });
+
+      // Act
+      const result = await createTweet(
+        { content: "Valid content", userId: 1 },
+        mockPrisma
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      expect(result.error.type).toBe(TweetErrorType.TWEET_CREATION_FAILED);
+    });
+  });
+});

--- a/api/src/services/tweetService.test.ts
+++ b/api/src/services/tweetService.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTweet } from "./tweetService.js";
-import * as tweetRepository from "../domain/tweet/tweetRepository.js";
-import { TweetErrorType } from "../utils/errors.js";
+import * as tweetRepository from "../domain/tweet/tweetRepository.ts";
+import { TweetErrorType } from "../utils/errors.ts";
+import { createTweet } from "./tweetService.ts";
 
-vi.mock("../domain/tweet/tweetRepository.js");
+vi.mock("../domain/tweet/tweetRepository.ts");
 
 describe("tweetService", () => {
   describe("createTweet", () => {
@@ -16,18 +16,24 @@ describe("tweetService", () => {
       // Act
       const emptyResult = await createTweet(
         { content: emptyContent, userId: 1 },
-        mockPrisma
+        mockPrisma,
       );
       const tooLongResult = await createTweet(
         { content: tooLongContent, userId: 1 },
-        mockPrisma
+        mockPrisma,
       );
 
       // Assert
       expect(emptyResult.ok).toBe(false);
-      expect(emptyResult.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      if (!emptyResult.ok) {
+        expect(emptyResult.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      }
       expect(tooLongResult.ok).toBe(false);
-      expect(tooLongResult.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      if (!tooLongResult.ok) {
+        expect(tooLongResult.error.type).toBe(
+          TweetErrorType.INVALID_TWEET_DATA,
+        );
+      }
     });
 
     it("should check if user exists", async () => {
@@ -41,12 +47,14 @@ describe("tweetService", () => {
       // Act
       const result = await createTweet(
         { content: "Valid content", userId: 999 },
-        mockPrisma
+        mockPrisma,
       );
 
       // Assert
       expect(result.ok).toBe(false);
-      expect(result.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      if (!result.ok) {
+        expect(result.error.type).toBe(TweetErrorType.INVALID_TWEET_DATA);
+      }
       expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
         where: { id: 999 },
       });
@@ -74,15 +82,17 @@ describe("tweetService", () => {
       // Act
       const result = await createTweet(
         { content: "Valid content", userId: 1 },
-        mockPrisma
+        mockPrisma,
       );
 
       // Assert
       expect(result.ok).toBe(true);
-      expect(result.value).toEqual(mockTweet);
+      if (result.ok) {
+        expect(result.value).toEqual(mockTweet);
+      }
       expect(tweetRepository.createTweet).toHaveBeenCalledWith(
         { content: "Valid content", userId: 1 },
-        mockPrisma
+        mockPrisma,
       );
     });
 
@@ -101,12 +111,14 @@ describe("tweetService", () => {
       // Act
       const result = await createTweet(
         { content: "Valid content", userId: 1 },
-        mockPrisma
+        mockPrisma,
       );
 
       // Assert
       expect(result.ok).toBe(false);
-      expect(result.error.type).toBe(TweetErrorType.TWEET_CREATION_FAILED);
+      if (!result.ok) {
+        expect(result.error.type).toBe(TweetErrorType.TWEET_CREATION_FAILED);
+      }
     });
   });
 });

--- a/api/src/services/tweetService.ts
+++ b/api/src/services/tweetService.ts
@@ -1,0 +1,71 @@
+import { PrismaClient } from "@prisma/client";
+import { createTweet as createTweetRepo } from "../domain/tweet/tweetRepository.js";
+import type { Result } from "../utils/result.js";
+import type { TweetCreateInput, TweetResponse } from "../types/index.js";
+import { TweetErrorType } from "../utils/errors.js";
+
+export const createTweet = async (
+  data: TweetCreateInput,
+  prisma: PrismaClient
+): Promise<Result<TweetResponse, { type: TweetErrorType; message: string }>> => {
+  // Validate content
+  if (!data.content || data.content.trim().length === 0) {
+    return {
+      ok: false,
+      error: {
+        type: TweetErrorType.INVALID_TWEET_DATA,
+        message: "Tweet content cannot be empty",
+      },
+    };
+  }
+
+  if (data.content.length > 280) {
+    return {
+      ok: false,
+      error: {
+        type: TweetErrorType.INVALID_TWEET_DATA,
+        message: "Tweet content cannot exceed 280 characters",
+      },
+    };
+  }
+
+  // Check if user exists
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: data.userId },
+    });
+
+    if (!user) {
+      return {
+        ok: false,
+        error: {
+          type: TweetErrorType.INVALID_TWEET_DATA,
+          message: "User not found",
+        },
+      };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        type: TweetErrorType.TWEET_CREATION_FAILED,
+        message: "Failed to verify user",
+      },
+    };
+  }
+
+  // Create tweet
+  const result = await createTweetRepo(data, prisma);
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: {
+        type: TweetErrorType.TWEET_CREATION_FAILED,
+        message: "Failed to create tweet",
+      },
+    };
+  }
+
+  return { ok: true, value: result.value };
+};

--- a/api/src/services/tweetService.ts
+++ b/api/src/services/tweetService.ts
@@ -1,13 +1,15 @@
-import { PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 import { createTweet as createTweetRepo } from "../domain/tweet/tweetRepository.js";
-import type { Result } from "../utils/result.js";
 import type { TweetCreateInput, TweetResponse } from "../types/index.js";
 import { TweetErrorType } from "../utils/errors.js";
+import type { Result } from "../utils/result.js";
 
 export const createTweet = async (
   data: TweetCreateInput,
-  prisma: PrismaClient
-): Promise<Result<TweetResponse, { type: TweetErrorType; message: string }>> => {
+  prisma: PrismaClient,
+): Promise<
+  Result<TweetResponse, { type: TweetErrorType; message: string }>
+> => {
   // Validate content
   if (!data.content || data.content.trim().length === 0) {
     return {

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -32,3 +32,16 @@ export type UserProfileResponse = {
   isVerified: boolean;
   createdAt: Date;
 };
+
+export type TweetCreateInput = {
+  content: string;
+  userId: number;
+};
+
+export type TweetResponse = {
+  id: number;
+  content: string;
+  userId: number;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/api/src/utils/errors.ts
+++ b/api/src/utils/errors.ts
@@ -42,3 +42,16 @@ export type ValidationError = {
   type: ValidationErrorType;
   message: string;
 };
+
+// ツイートエラータイプ
+export enum TweetErrorType {
+  INVALID_TWEET_DATA = "INVALID_TWEET_DATA",
+  TWEET_CREATION_FAILED = "TWEET_CREATION_FAILED",
+  UNAUTHORIZED_ACTION = "UNAUTHORIZED_ACTION",
+}
+
+// ツイートエラー
+export type TweetError = {
+  type: TweetErrorType;
+  message: string;
+};

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,7 +2,7 @@
 
 ## Current Focus
 
-The current development focus is on implementing the core backend functionality for X-Echo, with an emphasis on user management, authentication, and profile management. The project is in its early stages, with the basic project structure and database schema established. User registration, authentication, and profile management functionality has been implemented.
+The current development focus is on implementing the core backend functionality for X-Echo, with an emphasis on user management, authentication, profile management, and tweet functionality. The project is in its early stages, with the basic project structure and database schema established. User registration, authentication, profile management, and tweet creation functionality has been implemented.
 
 ## Recent Changes
 
@@ -33,6 +33,10 @@ The current development focus is on implementing the core backend functionality 
    - Implemented user profile retrieval endpoint
    - Added user profile update functionality with validation
    - Created integration tests for profile endpoints
+   - Implemented Tweet model in Prisma schema
+   - Added tweet creation functionality with validation
+   - Implemented tweet repository, service, and controller
+   - Created comprehensive tests for tweet creation
 
 ## Current Tasks
 
@@ -47,7 +51,13 @@ The current development focus is on implementing the core backend functionality 
    - ✅ Adding profile update functionality
    - ✅ Creating validation for profile data
 
-3. **Documentation**
+3. **Tweet Functionality**
+   - ✅ Implementing tweet creation API
+   - ✅ Adding validation for tweet content
+   - ✅ Creating tests for tweet functionality
+   - Implementing tweet retrieval endpoints
+
+4. **Documentation**
    - Documenting the database architecture
    - Creating implementation plans for user-related features
    - Establishing coding standards and patterns
@@ -76,7 +86,7 @@ The current development focus is on implementing the core backend functionality 
 ### Medium-term (Next 1-2 Months)
 
 1. **Tweet Functionality**
-   - Implement tweet creation
+   - ✅ Implement tweet creation
    - Add tweet retrieval (single and lists)
    - Create timeline functionality
    - Implement tweet deletion

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -21,6 +21,7 @@ The X-Echo project is in the early development phase, with the focus on establis
 ### Database
 - ✅ User model defined in Prisma schema
 - ✅ TokenBlacklist model added for JWT token management
+- ✅ Tweet model defined in Prisma schema
 - ✅ Prisma client setup for database access
 
 ### API
@@ -41,6 +42,9 @@ The X-Echo project is in the early development phase, with the focus on establis
 - ✅ User profile retrieval endpoint implemented
 - ✅ User profile update endpoint implemented (with authentication)
 - ✅ Profile data validation with Zod
+- ✅ Tweet creation API implemented
+- ✅ Tweet content validation with Zod
+- ✅ Authentication required for tweet creation
 
 ### Testing
 - ✅ Testing infrastructure set up with Vitest
@@ -54,6 +58,9 @@ The X-Echo project is in the early development phase, with the focus on establis
 - ✅ Unit tests for authentication middleware implemented
 - ✅ Unit tests for user profile controller implemented
 - ✅ Integration tests for user profile endpoints implemented
+- ✅ Unit tests for tweet repository implemented
+- ✅ Unit tests for tweet service implemented
+- ✅ Unit tests for tweet controller implemented
 
 ### Documentation
 - ✅ Database architecture documentation
@@ -76,7 +83,7 @@ The X-Echo project is in the early development phase, with the focus on establis
 - ❌ Follower/following lists
 
 ### Tweet Functionality
-- ❌ Tweet creation
+- ✅ Tweet creation
 - ❌ Tweet retrieval (single and lists)
 - ❌ Timeline functionality
 - ❌ Tweet deletion
@@ -131,7 +138,7 @@ The X-Echo project is in the early development phase, with the focus on establis
 **Target Completion**: TBD
 
 ### Milestone 2: Tweet Functionality
-- Tweet creation
+- ✅ Tweet creation
 - Tweet retrieval
 - Timeline implementation
 - Tweet interactions (favorites, retweets)

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -122,7 +122,7 @@ Additional models for Follow, Tweet, Favorite, and Retweet will be implemented a
 - `GET /api/users/:username/following` - Get users being followed
 
 ### Tweets
-- `POST /api/tweets` - Create a new tweet
+- ✅ `POST /api/tweets` - Create a new tweet
 - `GET /api/tweets/:id` - Get a specific tweet
 - `DELETE /api/tweets/:id` - Delete a tweet
 - `GET /api/users/:username/tweets` - Get tweets by a user


### PR DESCRIPTION
## 変更内容

- ツイートモデルをPrismaスキーマに追加
- ツイート作成リポジトリの実装
- ツイート作成サービスの実装
- ツイート作成コントローラーの実装
- ツイート作成エンドポイントの追加

## 変更の背景と目的

- ユーザーがツイートを投稿できるようにするための基本機能を実装
- プロジェクトの中核機能としてツイート作成機能は必須

## テスト結果

- [x] ユニットテスト実行済み
- [x] 動作確認済み

## 特記事項

- ツイート内容は1〜280文字に制限
- 認証済みユーザーのみがツイートを作成可能
- 現時点ではリツイートやお気に入り機能は未実装