### PR TITLE
style(auth): 不要なelseキーワードを削除

### DIFF
--- a/api/src/controllers/authController.ts
+++ b/api/src/controllers/authController.ts
@@ -22,10 +22,10 @@ export const login = async (c: Context) => {
         refreshToken: result.value.refreshToken,
         user: result.value.user,
       });
-    } else {
-      c.status(401);
-      return c.json({ error: result.error });
     }
+
+    c.status(401);
+    return c.json({ error: result.error });
   } catch (error) {
     // リクエストボディのパース失敗など
     console.error("Login error:", error);
@@ -56,10 +56,10 @@ export const refresh = async (c: Context) => {
         refreshToken: result.value.refreshToken,
         user: result.value.user,
       });
-    } else {
-      c.status(401);
-      return c.json({ error: result.error });
     }
+
+    c.status(401);
+    return c.json({ error: result.error });
   } catch (error) {
     // リクエストボディのパース失敗など
     console.error("Token refresh error:", error);
@@ -98,10 +98,10 @@ export const logout = async (c: Context) => {
     if (result.ok) {
       c.status(200);
       return c.json({ message: "ログアウトしました" });
-    } else {
-      c.status(500);
-      return c.json({ error: result.error });
     }
+
+    c.status(500);
+    return c.json({ error: result.error });
   } catch (error) {
     // 予期しないエラー
     console.error("Logout error:", error);

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -38,6 +38,12 @@ The current development focus is on implementing the core backend functionality 
    - Implemented tweet repository, service, and controller
    - Created comprehensive tests for tweet creation
 
+4. **Code Quality Improvements**
+   - Removed unnecessary `else` clauses in `authController.ts` to improve code readability
+   - Applied early return pattern to flatten conditional branches
+   - Updated `knowledge-transfer.md` with detailed guide on fixing `noUselessElse` warnings
+   - Ensured all tests pass after code style improvements
+
 ## Current Tasks
 
 1. **Authentication System**
@@ -147,3 +153,8 @@ The current development focus is on implementing the core backend functionality 
      - `Property 'mockReturnValueOnce' does not exist on type '{ (name: RequestHeader): string | undefined; ... }'`
    - Tests run successfully despite these type errors
    - Fixing would require extending Vitest's type definitions
+
+2. **Linting Warnings**
+   - Several `noExplicitAny` and `noImplicitAnyLet` warnings in test files
+   - `useLiteralKeys` warnings in some test files
+   - These warnings do not affect functionality but should be addressed for code quality

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -118,6 +118,7 @@ The X-Echo project is in the early development phase, with the focus on establis
 1. **Authentication Controller Response Format**: Fixed response format in `authController.ts` to use `c.status(statusCode); c.json(data);` instead of `c.json(data, statusCode)`
 2. **JWT Payload Type Definition**: Corrected `JwtPayload` type to use `Role` enum instead of `string` for the `role` property
 3. **Test Code Consistency**: Updated test code to use `Role.USER` enum value instead of `"USER"` string
+4. **Unnecessary `else` Clauses**: Removed unnecessary `else` clauses in `authController.ts` to improve code readability and follow early return pattern
 
 ### Blockers
 1. **None currently**: No critical blockers at this stage
@@ -167,6 +168,8 @@ The X-Echo project is in the early development phase, with the focus on establis
 - Using Biome for linting and formatting
 - TypeScript for type safety
 - Following established coding standards
+- Applying early return pattern to flatten conditional branches
+- Removing unnecessary `else` clauses when `if` blocks always return
 
 ### Development Process
 - Enforcing strict git workflow for all development work


### PR DESCRIPTION
## 変更内容

- authController.tsのlogin、refresh、logout関数から不要なelseキーワードを削除

## 変更の背景と目的

- if文の後に必ずreturnがある場合、elseキーワードは不要
- コードの可読性と保守性を向上させるため
- Biomeの警告を解消するため

## テスト結果

- [x] 単体テストが正常に実行されることを確認
- [x] npm run checkでlint警告が解消されたことを確認

## 考慮事項

- 機能的な変更はなく、コードスタイルの改善のみ
- プロジェクトの設計原則（早期リターン、フラットな条件分岐）に沿った修正