### PR TITLE
refactor: enumをconst objectパターンに置き換え

### DIFF
--- a/api/src/controllers/authController.test.ts
+++ b/api/src/controllers/authController.test.ts
@@ -1,4 +1,4 @@
-import { Role } from "@prisma/client";
+import { Role } from "../types/role.js";
 import type { Context } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as userRepository from "../domain/user/userRepository.js";

--- a/api/src/types/auth.ts
+++ b/api/src/types/auth.ts
@@ -1,4 +1,5 @@
-import type { Role, User } from "@prisma/client";
+import type { User } from "@prisma/client";
+import type { Role } from "./role.js";
 
 // ブランド型
 type Branded<T, B> = T & { _brand: B };

--- a/api/src/types/role.ts
+++ b/api/src/types/role.ts
@@ -1,0 +1,8 @@
+import type { Role as PrismaRole } from "@prisma/client";
+
+export const Role = {
+  USER: "USER",
+  ADMIN: "ADMIN",
+} as const satisfies Record<string, PrismaRole>;
+
+export type Role = (typeof Role)[keyof typeof Role];

--- a/api/src/utils/errors.ts
+++ b/api/src/utils/errors.ts
@@ -1,11 +1,13 @@
-export enum UserErrorType {
-  VALIDATION_ERROR = "VALIDATION_ERROR",
-  USER_ALREADY_EXISTS = "USER_ALREADY_EXISTS",
-  USER_NOT_FOUND = "USER_NOT_FOUND",
-  UNAUTHORIZED_UPDATE = "UNAUTHORIZED_UPDATE",
-  INVALID_PROFILE_DATA = "INVALID_PROFILE_DATA",
-  INTERNAL_ERROR = "INTERNAL_ERROR",
-}
+export const UserErrorType = {
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  USER_ALREADY_EXISTS: "USER_ALREADY_EXISTS",
+  USER_NOT_FOUND: "USER_NOT_FOUND",
+  UNAUTHORIZED_UPDATE: "UNAUTHORIZED_UPDATE",
+  INVALID_PROFILE_DATA: "INVALID_PROFILE_DATA",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const satisfies Record<string, string>;
+
+export type UserErrorType = (typeof UserErrorType)[keyof typeof UserErrorType];
 
 export type UserError = {
   type: UserErrorType;
@@ -13,15 +15,17 @@ export type UserError = {
 };
 
 // 認証エラータイプ
-export enum AuthErrorType {
-  INVALID_CREDENTIALS = "INVALID_CREDENTIALS",
-  TOKEN_EXPIRED = "TOKEN_EXPIRED",
-  REFRESH_TOKEN_EXPIRED = "REFRESH_TOKEN_EXPIRED",
-  INVALID_TOKEN = "INVALID_TOKEN",
-  INVALID_REFRESH_TOKEN = "INVALID_REFRESH_TOKEN",
-  USER_NOT_FOUND = "USER_NOT_FOUND",
-  INTERNAL_ERROR = "INTERNAL_ERROR",
-}
+export const AuthErrorType = {
+  INVALID_CREDENTIALS: "INVALID_CREDENTIALS",
+  TOKEN_EXPIRED: "TOKEN_EXPIRED",
+  REFRESH_TOKEN_EXPIRED: "REFRESH_TOKEN_EXPIRED",
+  INVALID_TOKEN: "INVALID_TOKEN",
+  INVALID_REFRESH_TOKEN: "INVALID_REFRESH_TOKEN",
+  USER_NOT_FOUND: "USER_NOT_FOUND",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const satisfies Record<string, string>;
+
+export type AuthErrorType = (typeof AuthErrorType)[keyof typeof AuthErrorType];
 
 // 認証エラー
 export type AuthError = {
@@ -30,12 +34,14 @@ export type AuthError = {
 };
 
 // バリデーションエラータイプ
-export enum ValidationErrorType {
-  INVALID_PASSWORD = "INVALID_PASSWORD",
-  INVALID_EMAIL = "INVALID_EMAIL",
-  INVALID_USERNAME = "INVALID_USERNAME",
-  INVALID_INPUT = "INVALID_INPUT",
-}
+export const ValidationErrorType = {
+  INVALID_PASSWORD: "INVALID_PASSWORD",
+  INVALID_EMAIL: "INVALID_EMAIL",
+  INVALID_USERNAME: "INVALID_USERNAME",
+  INVALID_INPUT: "INVALID_INPUT",
+} as const satisfies Record<string, string>;
+
+export type ValidationErrorType = (typeof ValidationErrorType)[keyof typeof ValidationErrorType];
 
 // バリデーションエラー
 export type ValidationError = {
@@ -44,13 +50,15 @@ export type ValidationError = {
 };
 
 // ツイートエラータイプ
-export enum TweetErrorType {
-  INVALID_TWEET_DATA = "INVALID_TWEET_DATA",
-  TWEET_CREATION_FAILED = "TWEET_CREATION_FAILED",
-  UNAUTHORIZED_ACTION = "UNAUTHORIZED_ACTION",
-  TWEET_NOT_FOUND = "TWEET_NOT_FOUND",
-  INTERNAL_ERROR = "INTERNAL_ERROR",
-}
+export const TweetErrorType = {
+  INVALID_TWEET_DATA: "INVALID_TWEET_DATA",
+  TWEET_CREATION_FAILED: "TWEET_CREATION_FAILED",
+  UNAUTHORIZED_ACTION: "UNAUTHORIZED_ACTION",
+  TWEET_NOT_FOUND: "TWEET_NOT_FOUND",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const satisfies Record<string, string>;
+
+export type TweetErrorType = (typeof TweetErrorType)[keyof typeof TweetErrorType];
 
 // ツイートエラー
 export type TweetError = {

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -62,6 +62,26 @@ Benefits:
 - Enforces domain constraints
 - Improves static analysis
 
+### Const Object Pattern
+Used instead of TypeScript enums to define a set of related constants:
+
+```typescript
+const UserErrorType = {
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  USER_ALREADY_EXISTS: "USER_ALREADY_EXISTS",
+  USER_NOT_FOUND: "USER_NOT_FOUND",
+} as const satisfies Record<string, string>;
+
+type UserErrorType = (typeof UserErrorType)[keyof typeof UserErrorType];
+```
+
+Benefits:
+- Smaller bundle size compared to TypeScript enums
+- Better type safety
+- More flexible type definitions
+- Easier to add or modify values
+- Avoids runtime issues with TypeScript enums
+
 ### Repository Pattern
 Used to abstract data access:
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -158,6 +158,19 @@ Additional models for Follow, Tweet, Favorite, and Retweet will be implemented a
 ### Code Quality
 - Linting and formatting using Biome
 - Type checking with TypeScript
+  - Avoid using TypeScript enums, prefer const object pattern instead:
+    ```typescript
+    // Instead of enum:
+    // enum Status { Active = "ACTIVE", Inactive = "INACTIVE" }
+
+    // Use const object pattern:
+    const Status = {
+      Active: "ACTIVE",
+      Inactive: "INACTIVE"
+    } as const satisfies Record<string, string>;
+
+    type Status = (typeof Status)[keyof typeof Status];
+    ```
 - Unit and integration testing with Vitest
 - Test-driven development approach
 


### PR DESCRIPTION
## 変更内容

- TypeScriptのenumをconst objectパターンに置き換え
- UserErrorType, AuthErrorType, ValidationErrorType, TweetErrorTypeを修正
- Prismaが生成するRole enumに対応するTypeScript型を作成
- 関連するインポートを更新

## 変更の背景と目的

- enumの使用を避けることでバンドルサイズの削減
- 型安全性の向上
- より柔軟な型定義の実現

## テスト結果

- [x] ユニットテスト実行済み
- [x] 動作確認済み