### PR TITLE
feature: フォロー機能のエンドポイントを追加

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -56,6 +56,18 @@ model Tweet {
   @@map("tweets")
 }
 
+model Follow {
+  id          Int      @id @default(autoincrement())
+  followerId  Int
+  followingId Int
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  @@unique([followerId, followingId])
+  @@index([followerId])
+  @@index([followingId])
+  @@map("follows")
+}
+
 enum Role {
   USER
   ADMIN

--- a/api/src/controllers/followController.test.ts
+++ b/api/src/controllers/followController.test.ts
@@ -6,7 +6,7 @@ import {
   getUserFollowersController,
   getUserFollowingController,
   unfollowUserController,
-} from "./followController.js";
+} from "./followController.ts";
 
 // Mock the followService
 vi.mock("../services/followService.js", () => ({

--- a/api/src/controllers/followController.test.ts
+++ b/api/src/controllers/followController.test.ts
@@ -1,0 +1,616 @@
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FollowErrorType, UserErrorType } from "../utils/errors.js";
+import {
+  followUserController,
+  getUserFollowersController,
+  getUserFollowingController,
+  unfollowUserController,
+} from "./followController.js";
+
+// Mock the followService
+vi.mock("../services/followService.js", () => ({
+  followUser: vi.fn(),
+  unfollowUser: vi.fn(),
+  getUserFollowers: vi.fn(),
+  getUserFollowing: vi.fn(),
+}));
+
+// Import the mocked services
+import {
+  followUser,
+  getUserFollowers,
+  getUserFollowing,
+  unfollowUser,
+} from "../services/followService.js";
+
+describe("followController", () => {
+  let mockContext: any;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.resetAllMocks();
+
+    // Create mock context
+    mockContext = {
+      get: vi.fn().mockReturnValue({ id: 1 }), // Mock JWT payload
+      req: {
+        param: vi.fn(),
+        query: vi.fn(),
+      },
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  describe("followUserController", () => {
+    it("should follow a user successfully", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(followUser).mockResolvedValue({
+        ok: true,
+        value: {
+          id: 1,
+          followerId: 1,
+          followingId: 2,
+          createdAt: new Date(),
+        },
+      });
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(followUser).toHaveBeenCalledWith(1, "testuser");
+      expect(mockContext.status).toHaveBeenCalledWith(201);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        follow: expect.objectContaining({
+          id: 1,
+          followerId: 1,
+          followingId: 2,
+        }),
+      });
+    });
+
+    it("should return 404 when user is not found", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("nonexistentuser");
+      vi.mocked(followUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(404);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+    });
+
+    it("should return 409 when already following", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(followUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.ALREADY_FOLLOWING,
+          message: "Already following this user",
+        },
+      });
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(409);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.ALREADY_FOLLOWING,
+          message: "Already following this user",
+        },
+      });
+    });
+
+    it("should return 400 when trying to follow self", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("currentuser");
+      vi.mocked(followUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.CANNOT_FOLLOW_SELF,
+          message: "Cannot follow yourself",
+        },
+      });
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(400);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.CANNOT_FOLLOW_SELF,
+          message: "Cannot follow yourself",
+        },
+      });
+    });
+
+    it("should return 500 on internal error", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(followUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal error",
+        },
+      });
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+
+    it("should handle unexpected errors", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(followUser).mockRejectedValue(new Error("Unexpected error"));
+
+      // Act
+      await followUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+  });
+
+  describe("unfollowUserController", () => {
+    it("should unfollow a user successfully", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(unfollowUser).mockResolvedValue({
+        ok: true,
+        value: undefined,
+      });
+
+      // Act
+      await unfollowUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(unfollowUser).toHaveBeenCalledWith(1, "testuser");
+      expect(mockContext.status).toHaveBeenCalledWith(200);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        message: "Successfully unfollowed user",
+      });
+    });
+
+    it("should return 404 when user is not found", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("nonexistentuser");
+      vi.mocked(unfollowUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      await unfollowUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(404);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+    });
+
+    it("should return 400 when not following", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(unfollowUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.NOT_FOLLOWING,
+          message: "Not following this user",
+        },
+      });
+
+      // Act
+      await unfollowUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(400);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.NOT_FOLLOWING,
+          message: "Not following this user",
+        },
+      });
+    });
+
+    it("should return 500 on internal error", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(unfollowUser).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal error",
+        },
+      });
+
+      // Act
+      await unfollowUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+
+    it("should handle unexpected errors", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      vi.mocked(unfollowUser).mockRejectedValue(new Error("Unexpected error"));
+
+      // Act
+      await unfollowUserController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+  });
+
+  describe("getUserFollowersController", () => {
+    it("should return followers with pagination", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowers).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { id: 1, followerId: 3, followingId: 2, createdAt: new Date() },
+            { id: 2, followerId: 4, followingId: 2, createdAt: new Date() },
+          ],
+          pagination: {
+            hasMore: true,
+            nextCursor: "1",
+          },
+        },
+      });
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(getUserFollowers).toHaveBeenCalledWith("testuser", { limit: 20 });
+      expect(mockContext.status).toHaveBeenCalledWith(200);
+      expect(mockContext.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          follows: expect.arrayContaining([
+            expect.objectContaining({ id: 1 }),
+            expect.objectContaining({ id: 2 }),
+          ]),
+          pagination: expect.objectContaining({
+            hasMore: true,
+            nextCursor: "1",
+          }),
+        })
+      );
+    });
+
+    it("should handle pagination parameters", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "10", cursor: "5" });
+      vi.mocked(getUserFollowers).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { id: 3, followerId: 5, followingId: 2, createdAt: new Date() },
+          ],
+          pagination: {
+            hasMore: false,
+            nextCursor: undefined,
+          },
+        },
+      });
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(getUserFollowers).toHaveBeenCalledWith("testuser", {
+        limit: 10,
+        cursor: 5,
+      });
+      expect(mockContext.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should return 400 for invalid pagination parameters", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "invalid" });
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(400);
+      expect(mockContext.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            type: "VALIDATION_ERROR",
+          }),
+        })
+      );
+    });
+
+    it("should return 404 when user is not found", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("nonexistentuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowers).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(404);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+    });
+
+    it("should return 500 on internal error", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowers).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal error",
+        },
+      });
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+
+    it("should handle unexpected errors", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowers).mockRejectedValue(
+        new Error("Unexpected error")
+      );
+
+      // Act
+      await getUserFollowersController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+  });
+
+  describe("getUserFollowingController", () => {
+    it("should return following users with pagination", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowing).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { id: 1, followerId: 2, followingId: 3, createdAt: new Date() },
+            { id: 2, followerId: 2, followingId: 4, createdAt: new Date() },
+          ],
+          pagination: {
+            hasMore: true,
+            nextCursor: "1",
+          },
+        },
+      });
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(getUserFollowing).toHaveBeenCalledWith("testuser", { limit: 20 });
+      expect(mockContext.status).toHaveBeenCalledWith(200);
+      expect(mockContext.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          follows: expect.arrayContaining([
+            expect.objectContaining({ id: 1 }),
+            expect.objectContaining({ id: 2 }),
+          ]),
+          pagination: expect.objectContaining({
+            hasMore: true,
+            nextCursor: "1",
+          }),
+        })
+      );
+    });
+
+    it("should handle pagination parameters", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "10", cursor: "5" });
+      vi.mocked(getUserFollowing).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { id: 3, followerId: 2, followingId: 5, createdAt: new Date() },
+          ],
+          pagination: {
+            hasMore: false,
+            nextCursor: undefined,
+          },
+        },
+      });
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(getUserFollowing).toHaveBeenCalledWith("testuser", {
+        limit: 10,
+        cursor: 5,
+      });
+      expect(mockContext.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should return 400 for invalid pagination parameters", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "invalid" });
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(400);
+      expect(mockContext.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            type: "VALIDATION_ERROR",
+          }),
+        })
+      );
+    });
+
+    it("should return 404 when user is not found", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("nonexistentuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowing).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(404);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+    });
+
+    it("should return 500 on internal error", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowing).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal error",
+        },
+      });
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+
+    it("should handle unexpected errors", async () => {
+      // Arrange
+      mockContext.req.param.mockReturnValue("testuser");
+      mockContext.req.query.mockReturnValue({ limit: "20" });
+      vi.mocked(getUserFollowing).mockRejectedValue(
+        new Error("Unexpected error")
+      );
+
+      // Act
+      await getUserFollowingController(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.status).toHaveBeenCalledWith(500);
+      expect(mockContext.json).toHaveBeenCalledWith({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    });
+  });
+});

--- a/api/src/controllers/followController.ts
+++ b/api/src/controllers/followController.ts
@@ -1,0 +1,287 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import {
+  followUser,
+  getUserFollowers,
+  getUserFollowing,
+  unfollowUser,
+} from "../services/followService.js";
+import { FollowErrorType, UserErrorType } from "../utils/errors.js";
+
+/**
+ * Follows a user
+ * @param c Hono context
+ * @returns Response with follow status or error
+ */
+export const followUserController = async (c: Context) => {
+  try {
+    // Get current user ID from JWT
+    const userId = c.get("jwtPayload").id;
+
+    // Get username from params
+    const username = c.req.param("username");
+
+    // Follow user
+    const result = await followUser(userId, username);
+
+    if (!result.ok) {
+      // Handle errors
+      if (result.error.type === UserErrorType.USER_NOT_FOUND) {
+        c.status(404);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      if (result.error.type === FollowErrorType.ALREADY_FOLLOWING) {
+        c.status(409);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      if (result.error.type === FollowErrorType.CANNOT_FOLLOW_SELF) {
+        c.status(400);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      c.status(500);
+      return c.json({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    }
+
+    // Return success response
+    c.status(201);
+    return c.json({
+      follow: result.value,
+    });
+  } catch (error) {
+    console.error("Error in followUserController:", error);
+    c.status(500);
+    return c.json({
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal server error",
+      },
+    });
+  }
+};
+
+/**
+ * Unfollows a user
+ * @param c Hono context
+ * @returns Response with success or error
+ */
+export const unfollowUserController = async (c: Context) => {
+  try {
+    // Get current user ID from JWT
+    const userId = c.get("jwtPayload").id;
+
+    // Get username from params
+    const username = c.req.param("username");
+
+    // Unfollow user
+    const result = await unfollowUser(userId, username);
+
+    if (!result.ok) {
+      // Handle errors
+      if (result.error.type === UserErrorType.USER_NOT_FOUND) {
+        c.status(404);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      if (result.error.type === FollowErrorType.NOT_FOLLOWING) {
+        c.status(400);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      c.status(500);
+      return c.json({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    }
+
+    // Return success response
+    c.status(200);
+    return c.json({
+      message: "Successfully unfollowed user",
+    });
+  } catch (error) {
+    console.error("Error in unfollowUserController:", error);
+    c.status(500);
+    return c.json({
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal server error",
+      },
+    });
+  }
+};
+
+/**
+ * Gets the followers of a user
+ * @param c Hono context
+ * @returns Response with followers list or error
+ */
+export const getUserFollowersController = async (c: Context) => {
+  try {
+    // Get username from params
+    const username = c.req.param("username");
+
+    // Validate query parameters
+    const schema = z.object({
+      limit: z.coerce.number().int().min(1).max(100).default(20),
+      cursor: z.coerce.number().int().optional(),
+    });
+
+    const validationResult = schema.safeParse(c.req.query());
+
+    if (!validationResult.success) {
+      c.status(400);
+      return c.json({
+        error: {
+          type: "VALIDATION_ERROR",
+          message: "Invalid pagination parameters",
+          details: validationResult.error.format(),
+        },
+      });
+    }
+
+    const { limit, cursor } = validationResult.data;
+
+    // Get followers
+    const result = await getUserFollowers(username, { limit, cursor });
+
+    if (!result.ok) {
+      // Handle errors
+      if (result.error.type === UserErrorType.USER_NOT_FOUND) {
+        c.status(404);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      c.status(500);
+      return c.json({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    }
+
+    // Return success response
+    c.status(200);
+    return c.json(result.value);
+  } catch (error) {
+    console.error("Error in getUserFollowersController:", error);
+    c.status(500);
+    return c.json({
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal server error",
+      },
+    });
+  }
+};
+
+/**
+ * Gets the users that a user is following
+ * @param c Hono context
+ * @returns Response with following list or error
+ */
+export const getUserFollowingController = async (c: Context) => {
+  try {
+    // Get username from params
+    const username = c.req.param("username");
+
+    // Validate query parameters
+    const schema = z.object({
+      limit: z.coerce.number().int().min(1).max(100).default(20),
+      cursor: z.coerce.number().int().optional(),
+    });
+
+    const validationResult = schema.safeParse(c.req.query());
+
+    if (!validationResult.success) {
+      c.status(400);
+      return c.json({
+        error: {
+          type: "VALIDATION_ERROR",
+          message: "Invalid pagination parameters",
+          details: validationResult.error.format(),
+        },
+      });
+    }
+
+    const { limit, cursor } = validationResult.data;
+
+    // Get following users
+    const result = await getUserFollowing(username, { limit, cursor });
+
+    if (!result.ok) {
+      // Handle errors
+      if (result.error.type === UserErrorType.USER_NOT_FOUND) {
+        c.status(404);
+        return c.json({
+          error: {
+            type: result.error.type,
+            message: result.error.message,
+          },
+        });
+      }
+
+      c.status(500);
+      return c.json({
+        error: {
+          type: FollowErrorType.INTERNAL_ERROR,
+          message: "Internal server error",
+        },
+      });
+    }
+
+    // Return success response
+    c.status(200);
+    return c.json(result.value);
+  } catch (error) {
+    console.error("Error in getUserFollowingController:", error);
+    c.status(500);
+    return c.json({
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal server error",
+      },
+    });
+  }
+};

--- a/api/src/domain/follow/followRepository.test.ts
+++ b/api/src/domain/follow/followRepository.test.ts
@@ -1,0 +1,332 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FollowErrorType } from "../../utils/errors.js";
+import {
+  checkFollowStatus,
+  createFollow,
+  deleteFollow,
+  getFollowers,
+  getFollowing,
+} from "./followRepository.ts";
+
+describe("followRepository", () => {
+  let mockPrisma: any;
+  const mockFollow = {
+    id: 1,
+    followerId: 1,
+    followingId: 2,
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    mockPrisma = {
+      follow: {
+        create: vi.fn(),
+        findFirst: vi.fn(),
+        delete: vi.fn(),
+        findMany: vi.fn(),
+      },
+      user: {
+        update: vi.fn(),
+      },
+      $transaction: vi.fn().mockImplementation((callbacks) => Promise.all(callbacks)),
+    };
+  });
+
+  describe("createFollow", () => {
+    it("should create a follow relationship successfully", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(null);
+      mockPrisma.follow.create.mockResolvedValue(mockFollow);
+      mockPrisma.user.update.mockResolvedValue({});
+
+      // Act
+      const result = await createFollow(
+        { followerId: 1, followingId: 2 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual(mockFollow);
+      }
+      expect(mockPrisma.follow.create).toHaveBeenCalledWith({
+        data: { followerId: 1, followingId: 2 },
+      });
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it("should return error when trying to follow self", async () => {
+      // Act
+      const result = await createFollow(
+        { followerId: 1, followingId: 1 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.CANNOT_FOLLOW_SELF);
+      }
+      expect(mockPrisma.follow.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when already following", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(mockFollow);
+
+      // Act
+      const result = await createFollow(
+        { followerId: 1, followingId: 2 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.ALREADY_FOLLOWING);
+      }
+      expect(mockPrisma.follow.create).not.toHaveBeenCalled();
+    });
+
+    it("should return error when database throws error", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockRejectedValue(new Error("Database error"));
+
+      // Act
+      const result = await createFollow(
+        { followerId: 1, followingId: 2 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.INTERNAL_ERROR);
+      }
+    });
+  });
+
+  describe("deleteFollow", () => {
+    it("should delete a follow relationship successfully", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(mockFollow);
+      mockPrisma.follow.delete.mockResolvedValue(mockFollow);
+      mockPrisma.user.update.mockResolvedValue({});
+
+      // Act
+      const result = await deleteFollow(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(mockPrisma.follow.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it("should return error when not following", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result = await deleteFollow(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.NOT_FOLLOWING);
+      }
+      expect(mockPrisma.follow.delete).not.toHaveBeenCalled();
+    });
+
+    it("should return error when database throws error", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockRejectedValue(new Error("Database error"));
+
+      // Act
+      const result = await deleteFollow(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.INTERNAL_ERROR);
+      }
+    });
+  });
+
+  describe("checkFollowStatus", () => {
+    it("should return true when following", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(mockFollow);
+
+      // Act
+      const result = await checkFollowStatus(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(true);
+      }
+    });
+
+    it("should return false when not following", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result = await checkFollowStatus(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(false);
+      }
+    });
+
+    it("should return error when database throws error", async () => {
+      // Arrange
+      mockPrisma.follow.findFirst.mockRejectedValue(new Error("Database error"));
+
+      // Act
+      const result = await checkFollowStatus(1, 2, mockPrisma as PrismaClient);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.INTERNAL_ERROR);
+      }
+    });
+  });
+
+  describe("getFollowers", () => {
+    it("should return followers with pagination", async () => {
+      // Arrange
+      const mockFollows = [
+        { ...mockFollow, id: 3 },
+        { ...mockFollow, id: 2 },
+        { ...mockFollow, id: 1 },
+      ];
+      mockPrisma.follow.findMany.mockResolvedValue(mockFollows);
+
+      // Act
+      const result = await getFollowers(
+        2,
+        { limit: 2 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(2);
+        expect(result.value.hasMore).toBe(true);
+        expect(result.value.nextCursor).toBe(2);
+      }
+    });
+
+    it("should handle empty followers list", async () => {
+      // Arrange
+      mockPrisma.follow.findMany.mockResolvedValue([]);
+
+      // Act
+      const result = await getFollowers(
+        2,
+        { limit: 10 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(0);
+        expect(result.value.hasMore).toBe(false);
+        expect(result.value.nextCursor).toBeUndefined();
+      }
+    });
+
+    it("should return error when database throws error", async () => {
+      // Arrange
+      mockPrisma.follow.findMany.mockRejectedValue(new Error("Database error"));
+
+      // Act
+      const result = await getFollowers(
+        2,
+        { limit: 10 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.INTERNAL_ERROR);
+      }
+    });
+  });
+
+  describe("getFollowing", () => {
+    it("should return following users with pagination", async () => {
+      // Arrange
+      const mockFollows = [
+        { ...mockFollow, id: 3 },
+        { ...mockFollow, id: 2 },
+        { ...mockFollow, id: 1 },
+      ];
+      mockPrisma.follow.findMany.mockResolvedValue(mockFollows);
+
+      // Act
+      const result = await getFollowing(
+        1,
+        { limit: 2 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(2);
+        expect(result.value.hasMore).toBe(true);
+        expect(result.value.nextCursor).toBe(2);
+      }
+    });
+
+    it("should handle empty following list", async () => {
+      // Arrange
+      mockPrisma.follow.findMany.mockResolvedValue([]);
+
+      // Act
+      const result = await getFollowing(
+        1,
+        { limit: 10 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(0);
+        expect(result.value.hasMore).toBe(false);
+        expect(result.value.nextCursor).toBeUndefined();
+      }
+    });
+
+    it("should return error when database throws error", async () => {
+      // Arrange
+      mockPrisma.follow.findMany.mockRejectedValue(new Error("Database error"));
+
+      // Act
+      const result = await getFollowing(
+        1,
+        { limit: 10 },
+        mockPrisma as PrismaClient,
+      );
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.INTERNAL_ERROR);
+      }
+    });
+  });
+});

--- a/api/src/domain/follow/followRepository.ts
+++ b/api/src/domain/follow/followRepository.ts
@@ -1,0 +1,279 @@
+import type { Follow, PrismaClient } from "@prisma/client";
+import type { FollowCreateInput, FollowPaginationParams } from "../../types/index.js";
+import type { FollowError } from "../../utils/errors.js";
+import { FollowErrorType } from "../../utils/errors.js";
+import type { Result } from "../../utils/result.js";
+
+/**
+ * Creates a follow relationship between two users
+ * @param data Follow creation input data
+ * @param prisma Prisma client instance
+ * @returns Result containing the created follow relationship or an error
+ */
+export const createFollow = async (
+  data: FollowCreateInput,
+  prisma: PrismaClient
+): Promise<Result<Follow, FollowError>> => {
+  try {
+    // Check if user is trying to follow themselves
+    if (data.followerId === data.followingId) {
+      return {
+        ok: false,
+        error: {
+          type: FollowErrorType.CANNOT_FOLLOW_SELF,
+          message: "Cannot follow yourself",
+        },
+      };
+    }
+
+    // Check if already following
+    const existingFollow = await prisma.follow.findFirst({
+      where: {
+        followerId: data.followerId,
+        followingId: data.followingId,
+      },
+    });
+
+    if (existingFollow) {
+      return {
+        ok: false,
+        error: {
+          type: FollowErrorType.ALREADY_FOLLOWING,
+          message: "Already following this user",
+        },
+      };
+    }
+
+    // Create follow relationship
+    const follow = await prisma.follow.create({
+      data,
+    });
+
+    // Update follower and following counts
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: data.followingId },
+        data: { followersCount: { increment: 1 } },
+      }),
+      prisma.user.update({
+        where: { id: data.followerId },
+        data: { followingCount: { increment: 1 } },
+      }),
+    ]);
+
+    return { ok: true, value: follow };
+  } catch (error) {
+    console.error("Error creating follow:", error);
+    return {
+      ok: false,
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal error occurred while creating follow relationship",
+      },
+    };
+  }
+};
+
+/**
+ * Deletes a follow relationship between two users
+ * @param followerId ID of the follower
+ * @param followingId ID of the user being followed
+ * @param prisma Prisma client instance
+ * @returns Result indicating success or an error
+ */
+export const deleteFollow = async (
+  followerId: number,
+  followingId: number,
+  prisma: PrismaClient
+): Promise<Result<void, FollowError>> => {
+  try {
+    // Find the follow relationship
+    const follow = await prisma.follow.findFirst({
+      where: {
+        followerId,
+        followingId,
+      },
+    });
+
+    if (!follow) {
+      return {
+        ok: false,
+        error: {
+          type: FollowErrorType.NOT_FOLLOWING,
+          message: "Not following this user",
+        },
+      };
+    }
+
+    // Delete the follow relationship
+    await prisma.follow.delete({
+      where: {
+        id: follow.id,
+      },
+    });
+
+    // Update follower and following counts
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: followingId },
+        data: { followersCount: { decrement: 1 } },
+      }),
+      prisma.user.update({
+        where: { id: followerId },
+        data: { followingCount: { decrement: 1 } },
+      }),
+    ]);
+
+    return { ok: true, value: undefined };
+  } catch (error) {
+    console.error("Error deleting follow:", error);
+    return {
+      ok: false,
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal error occurred while deleting follow relationship",
+      },
+    };
+  }
+};
+
+/**
+ * Checks if a user is following another user
+ * @param followerId ID of the follower
+ * @param followingId ID of the user being followed
+ * @param prisma Prisma client instance
+ * @returns Result containing the follow status or an error
+ */
+export const checkFollowStatus = async (
+  followerId: number,
+  followingId: number,
+  prisma: PrismaClient
+): Promise<Result<boolean, FollowError>> => {
+  try {
+    const follow = await prisma.follow.findFirst({
+      where: {
+        followerId,
+        followingId,
+      },
+    });
+
+    return { ok: true, value: !!follow };
+  } catch (error) {
+    console.error("Error checking follow status:", error);
+    return {
+      ok: false,
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal error occurred while checking follow status",
+      },
+    };
+  }
+};
+
+/**
+ * Gets the followers of a user with pagination
+ * @param userId ID of the user
+ * @param params Pagination parameters
+ * @param prisma Prisma client instance
+ * @returns Result containing the followers and pagination info or an error
+ */
+export const getFollowers = async (
+  userId: number,
+  params: FollowPaginationParams,
+  prisma: PrismaClient
+): Promise<Result<{ follows: Follow[]; hasMore: boolean; nextCursor?: number }, FollowError>> => {
+  try {
+    const { limit, cursor } = params;
+
+    // Implement cursor-based pagination
+    const follows = await prisma.follow.findMany({
+      where: {
+        followingId: userId,
+        ...(cursor ? { id: { lt: cursor } } : {}),
+      },
+      orderBy: [
+        { id: "desc" },
+      ],
+      take: limit + 1, // Fetch one more to determine if there are more results
+    });
+
+    const hasMore = follows.length > limit;
+    if (hasMore) {
+      follows.pop(); // Remove the extra item
+    }
+
+    const nextCursor = hasMore ? follows[follows.length - 1].id : undefined;
+
+    return {
+      ok: true,
+      value: {
+        follows,
+        hasMore,
+        nextCursor,
+      },
+    };
+  } catch (error) {
+    console.error("Error getting followers:", error);
+    return {
+      ok: false,
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal error occurred while getting followers",
+      },
+    };
+  }
+};
+
+/**
+ * Gets the users that a user is following with pagination
+ * @param userId ID of the user
+ * @param params Pagination parameters
+ * @param prisma Prisma client instance
+ * @returns Result containing the following users and pagination info or an error
+ */
+export const getFollowing = async (
+  userId: number,
+  params: FollowPaginationParams,
+  prisma: PrismaClient
+): Promise<Result<{ follows: Follow[]; hasMore: boolean; nextCursor?: number }, FollowError>> => {
+  try {
+    const { limit, cursor } = params;
+
+    // Implement cursor-based pagination
+    const follows = await prisma.follow.findMany({
+      where: {
+        followerId: userId,
+        ...(cursor ? { id: { lt: cursor } } : {}),
+      },
+      orderBy: [
+        { id: "desc" },
+      ],
+      take: limit + 1, // Fetch one more to determine if there are more results
+    });
+
+    const hasMore = follows.length > limit;
+    if (hasMore) {
+      follows.pop(); // Remove the extra item
+    }
+
+    const nextCursor = hasMore ? follows[follows.length - 1].id : undefined;
+
+    return {
+      ok: true,
+      value: {
+        follows,
+        hasMore,
+        nextCursor,
+      },
+    };
+  } catch (error) {
+    console.error("Error getting following:", error);
+    return {
+      ok: false,
+      error: {
+        type: FollowErrorType.INTERNAL_ERROR,
+        message: "Internal error occurred while getting following users",
+      },
+    };
+  }
+};

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,6 +1,12 @@
 import { Hono } from "hono";
 import { getUserTweets } from "../controllers/tweetController.js";
 import {
+  followUserController,
+  getUserFollowersController,
+  getUserFollowingController,
+  unfollowUserController,
+} from "../controllers/followController.js";
+import {
   getUserProfile,
   registerUser,
   updateUserProfile,
@@ -20,5 +26,11 @@ usersRouter.put("/profile", authenticate, updateUserProfile);
 
 // ユーザーのツイート一覧取得エンドポイント
 usersRouter.get("/:username/tweets", getUserTweets);
+
+// フォロー関連のエンドポイント
+usersRouter.post("/:username/follow", authenticate, followUserController);
+usersRouter.delete("/:username/follow", authenticate, unfollowUserController);
+usersRouter.get("/:username/followers", getUserFollowersController);
+usersRouter.get("/:username/following", getUserFollowingController);
 
 export default usersRouter;

--- a/api/src/services/followService.test.ts
+++ b/api/src/services/followService.test.ts
@@ -1,0 +1,497 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as followRepository from "../domain/follow/followRepository.js";
+import * as userRepository from "../domain/user/userRepository.js";
+import { FollowErrorType, UserErrorType } from "../utils/errors.js";
+import { Role } from "../types/role.js";
+import {
+  followUser,
+  getUserFollowers,
+  getUserFollowing,
+  getUserProfileWithFollowStatus,
+  isFollowing,
+  unfollowUser,
+} from "./followService.js";
+
+vi.mock("../domain/follow/followRepository.js");
+vi.mock("../domain/user/userRepository.js");
+vi.mock("../lib/prisma.js", () => ({
+  default: {},
+}));
+
+describe("followService", () => {
+  const mockUser = {
+    id: 2,
+    username: "testuser",
+    displayName: "Test User",
+    email: "test@example.com",
+    passwordHash: "hashedpassword",
+    bio: "Test bio",
+    profileImageUrl: null,
+    headerImageUrl: null,
+    followersCount: 0,
+    followingCount: 0,
+    isVerified: false,
+    isActive: true,
+    role: Role.USER,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockFollow = {
+    id: 1,
+    followerId: 1,
+    followingId: 2,
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("followUser", () => {
+    it("should follow a user successfully", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.createFollow).mockResolvedValue({
+        ok: true,
+        value: mockFollow,
+      });
+
+      // Act
+      const result = await followUser(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({
+          id: 1,
+          followerId: 1,
+          followingId: 2,
+          createdAt: expect.any(Date),
+        });
+      }
+      expect(userRepository.findUserByUsername).toHaveBeenCalledWith(
+        "testuser",
+        expect.anything()
+      );
+      expect(followRepository.createFollow).toHaveBeenCalledWith(
+        { followerId: 1, followingId: 2 },
+        expect.anything()
+      );
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await followUser(1, "nonexistentuser");
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+      expect(followRepository.createFollow).not.toHaveBeenCalled();
+    });
+
+    it("should return error when already following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.createFollow).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.ALREADY_FOLLOWING,
+          message: "Already following this user",
+        },
+      });
+
+      // Act
+      const result = await followUser(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.ALREADY_FOLLOWING);
+      }
+    });
+  });
+
+  describe("unfollowUser", () => {
+    it("should unfollow a user successfully", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.deleteFollow).mockResolvedValue({
+        ok: true,
+        value: undefined,
+      });
+
+      // Act
+      const result = await unfollowUser(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(userRepository.findUserByUsername).toHaveBeenCalledWith(
+        "testuser",
+        expect.anything()
+      );
+      expect(followRepository.deleteFollow).toHaveBeenCalledWith(
+        1,
+        2,
+        expect.anything()
+      );
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await unfollowUser(1, "nonexistentuser");
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+      expect(followRepository.deleteFollow).not.toHaveBeenCalled();
+    });
+
+    it("should return error when not following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.deleteFollow).mockResolvedValue({
+        ok: false,
+        error: {
+          type: FollowErrorType.NOT_FOLLOWING,
+          message: "Not following this user",
+        },
+      });
+
+      // Act
+      const result = await unfollowUser(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(FollowErrorType.NOT_FOLLOWING);
+      }
+    });
+  });
+
+  describe("isFollowing", () => {
+    it("should return true when following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.checkFollowStatus).mockResolvedValue({
+        ok: true,
+        value: true,
+      });
+
+      // Act
+      const result = await isFollowing(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(true);
+      }
+      expect(userRepository.findUserByUsername).toHaveBeenCalledWith(
+        "testuser",
+        expect.anything()
+      );
+      expect(followRepository.checkFollowStatus).toHaveBeenCalledWith(
+        1,
+        2,
+        expect.anything()
+      );
+    });
+
+    it("should return false when not following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.checkFollowStatus).mockResolvedValue({
+        ok: true,
+        value: false,
+      });
+
+      // Act
+      const result = await isFollowing(1, "testuser");
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(false);
+      }
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await isFollowing(1, "nonexistentuser");
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+      expect(followRepository.checkFollowStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getUserProfileWithFollowStatus", () => {
+    it("should return user profile with follow status when following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.checkFollowStatus).mockResolvedValue({
+        ok: true,
+        value: true,
+      });
+
+      // Act
+      const result = await getUserProfileWithFollowStatus("testuser", 1);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({
+          id: 2,
+          username: "testuser",
+          displayName: "Test User",
+          bio: "Test bio",
+          profileImageUrl: null,
+          headerImageUrl: null,
+          followersCount: 0,
+          followingCount: 0,
+          isVerified: false,
+          createdAt: expect.any(Date),
+          isFollowing: true,
+        });
+      }
+    });
+
+    it("should return user profile with isFollowing=false when not following", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.checkFollowStatus).mockResolvedValue({
+        ok: true,
+        value: false,
+      });
+
+      // Act
+      const result = await getUserProfileWithFollowStatus("testuser", 1);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.isFollowing).toBe(false);
+      }
+    });
+
+    it("should return user profile with isFollowing=false when no current user", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+
+      // Act
+      const result = await getUserProfileWithFollowStatus("testuser");
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.isFollowing).toBe(false);
+      }
+      expect(followRepository.checkFollowStatus).not.toHaveBeenCalled();
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await getUserProfileWithFollowStatus("nonexistentuser", 1);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+    });
+  });
+
+  describe("getUserFollowers", () => {
+    it("should return followers with pagination", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.getFollowers).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { ...mockFollow, id: 2, followerId: 3 },
+            { ...mockFollow, id: 1, followerId: 1 },
+          ],
+          hasMore: true,
+          nextCursor: 1,
+        },
+      });
+
+      // Act
+      const result = await getUserFollowers("testuser", { limit: 2 });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(2);
+        expect(result.value.pagination.hasMore).toBe(true);
+        expect(result.value.pagination.nextCursor).toBe("1");
+      }
+      expect(userRepository.findUserByUsername).toHaveBeenCalledWith(
+        "testuser",
+        expect.anything()
+      );
+      expect(followRepository.getFollowers).toHaveBeenCalledWith(
+        2,
+        { limit: 2 },
+        expect.anything()
+      );
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await getUserFollowers("nonexistentuser", { limit: 10 });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+      expect(followRepository.getFollowers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getUserFollowing", () => {
+    it("should return following users with pagination", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: true,
+        value: mockUser,
+      });
+      vi.mocked(followRepository.getFollowing).mockResolvedValue({
+        ok: true,
+        value: {
+          follows: [
+            { ...mockFollow, id: 2, followingId: 3 },
+            { ...mockFollow, id: 1, followingId: 4 },
+          ],
+          hasMore: true,
+          nextCursor: 1,
+        },
+      });
+
+      // Act
+      const result = await getUserFollowing("testuser", { limit: 2 });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.follows).toHaveLength(2);
+        expect(result.value.pagination.hasMore).toBe(true);
+        expect(result.value.pagination.nextCursor).toBe("1");
+      }
+      expect(userRepository.findUserByUsername).toHaveBeenCalledWith(
+        "testuser",
+        expect.anything()
+      );
+      expect(followRepository.getFollowing).toHaveBeenCalledWith(
+        2,
+        { limit: 2 },
+        expect.anything()
+      );
+    });
+
+    it("should return error when user is not found", async () => {
+      // Arrange
+      vi.mocked(userRepository.findUserByUsername).mockResolvedValue({
+        ok: false,
+        error: {
+          type: UserErrorType.USER_NOT_FOUND,
+          message: "User not found",
+        },
+      });
+
+      // Act
+      const result = await getUserFollowing("nonexistentuser", { limit: 10 });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe(UserErrorType.USER_NOT_FOUND);
+      }
+      expect(followRepository.getFollowing).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/services/followService.ts
+++ b/api/src/services/followService.ts
@@ -1,0 +1,251 @@
+import type { PrismaClient } from "@prisma/client";
+import {
+  checkFollowStatus,
+  createFollow,
+  deleteFollow,
+  getFollowers,
+  getFollowing,
+} from "../domain/follow/followRepository.ts";
+import { findUserByUsername } from "../domain/user/userRepository.ts";
+import type { FollowListResponse, FollowPaginationParams, FollowResponse, UserProfileResponse } from "../types/index.js";
+import type { FollowError } from "../utils/errors.js";
+import { FollowErrorType, UserErrorType } from "../utils/errors.js";
+import type { Result } from "../utils/result.js";
+import prisma from "../lib/prisma.js";
+
+/**
+ * Follows a user
+ * @param followerId ID of the follower
+ * @param username Username of the user to follow
+ * @returns Result containing the follow relationship or an error
+ */
+export const followUser = async (
+  followerId: number,
+  username: string
+): Promise<Result<FollowResponse, FollowError | { type: UserErrorType; message: string }>> => {
+  // Find the user to follow
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const followingId = userResult.value.id;
+
+  // Create follow relationship
+  const followResult = await createFollow(
+    { followerId, followingId },
+    prisma
+  );
+
+  if (!followResult.ok) {
+    return followResult;
+  }
+
+  return {
+    ok: true,
+    value: {
+      id: followResult.value.id,
+      followerId: followResult.value.followerId,
+      followingId: followResult.value.followingId,
+      createdAt: followResult.value.createdAt,
+    },
+  };
+};
+
+/**
+ * Unfollows a user
+ * @param followerId ID of the follower
+ * @param username Username of the user to unfollow
+ * @returns Result indicating success or an error
+ */
+export const unfollowUser = async (
+  followerId: number,
+  username: string
+): Promise<Result<void, FollowError | { type: UserErrorType; message: string }>> => {
+  // Find the user to unfollow
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const followingId = userResult.value.id;
+
+  // Delete follow relationship
+  return await deleteFollow(followerId, followingId, prisma);
+};
+
+/**
+ * Checks if a user is following another user
+ * @param followerId ID of the follower
+ * @param username Username of the user to check
+ * @returns Result containing the follow status or an error
+ */
+export const isFollowing = async (
+  followerId: number,
+  username: string
+): Promise<Result<boolean, FollowError | { type: UserErrorType; message: string }>> => {
+  // Find the user to check
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const followingId = userResult.value.id;
+
+  // Check follow status
+  return await checkFollowStatus(followerId, followingId, prisma);
+};
+
+/**
+ * Gets a user profile with follow status
+ * @param username Username of the user
+ * @param currentUserId ID of the current user (optional)
+ * @returns Result containing the user profile with follow status or an error
+ */
+export const getUserProfileWithFollowStatus = async (
+  username: string,
+  currentUserId?: number
+): Promise<Result<UserProfileResponse & { isFollowing: boolean }, { type: UserErrorType | FollowErrorType; message: string }>> => {
+  // Get user profile
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const user = userResult.value;
+
+  // If no current user ID is provided, set isFollowing to false
+  if (!currentUserId) {
+    return {
+      ok: true,
+      value: {
+        id: user.id,
+        username: user.username,
+        displayName: user.displayName,
+        bio: user.bio,
+        profileImageUrl: user.profileImageUrl,
+        headerImageUrl: user.headerImageUrl,
+        followersCount: user.followersCount,
+        followingCount: user.followingCount,
+        isVerified: user.isVerified,
+        createdAt: user.createdAt,
+        isFollowing: false,
+      },
+    };
+  }
+
+  // Check follow status
+  const followStatusResult = await checkFollowStatus(currentUserId, user.id, prisma);
+  if (!followStatusResult.ok) {
+    return followStatusResult;
+  }
+
+  return {
+    ok: true,
+    value: {
+      id: user.id,
+      username: user.username,
+      displayName: user.displayName,
+      bio: user.bio,
+      profileImageUrl: user.profileImageUrl,
+      headerImageUrl: user.headerImageUrl,
+      followersCount: user.followersCount,
+      followingCount: user.followingCount,
+      isVerified: user.isVerified,
+      createdAt: user.createdAt,
+      isFollowing: followStatusResult.value,
+    },
+  };
+};
+
+/**
+ * Gets the followers of a user
+ * @param username Username of the user
+ * @param params Pagination parameters
+ * @returns Result containing the followers and pagination info or an error
+ */
+export const getUserFollowers = async (
+  username: string,
+  params: FollowPaginationParams
+): Promise<Result<FollowListResponse, FollowError | { type: UserErrorType; message: string }>> => {
+  // Find the user
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const userId = userResult.value.id;
+
+  // Get followers
+  const followersResult = await getFollowers(userId, params, prisma);
+  if (!followersResult.ok) {
+    return followersResult;
+  }
+
+  const { follows, hasMore, nextCursor } = followersResult.value;
+
+  // Format response
+  const followResponses: FollowResponse[] = follows.map((follow) => ({
+    id: follow.id,
+    followerId: follow.followerId,
+    followingId: follow.followingId,
+    createdAt: follow.createdAt,
+  }));
+
+  return {
+    ok: true,
+    value: {
+      follows: followResponses,
+      pagination: {
+        hasMore,
+        nextCursor: nextCursor?.toString(),
+      },
+    },
+  };
+};
+
+/**
+ * Gets the users that a user is following
+ * @param username Username of the user
+ * @param params Pagination parameters
+ * @returns Result containing the following users and pagination info or an error
+ */
+export const getUserFollowing = async (
+  username: string,
+  params: FollowPaginationParams
+): Promise<Result<FollowListResponse, FollowError | { type: UserErrorType; message: string }>> => {
+  // Find the user
+  const userResult = await findUserByUsername(username, prisma);
+  if (!userResult.ok) {
+    return userResult;
+  }
+
+  const userId = userResult.value.id;
+
+  // Get following users
+  const followingResult = await getFollowing(userId, params, prisma);
+  if (!followingResult.ok) {
+    return followingResult;
+  }
+
+  const { follows, hasMore, nextCursor } = followingResult.value;
+
+  // Format response
+  const followResponses: FollowResponse[] = follows.map((follow) => ({
+    id: follow.id,
+    followerId: follow.followerId,
+    followingId: follow.followingId,
+    createdAt: follow.createdAt,
+  }));
+
+  return {
+    ok: true,
+    value: {
+      follows: followResponses,
+      pagination: {
+        hasMore,
+        nextCursor: nextCursor?.toString(),
+      },
+    },
+  };
+};

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -60,3 +60,37 @@ export type PaginationParams = {
   limit: number;
   cursor?: number;
 };
+
+// フォロー作成入力型
+export type FollowCreateInput = {
+  followerId: number;
+  followingId: number;
+};
+
+// フォローレスポンス型
+export type FollowResponse = {
+  id: number;
+  followerId: number;
+  followingId: number;
+  createdAt: Date;
+};
+
+// フォローページネーションパラメータ型
+export type FollowPaginationParams = {
+  limit: number;
+  cursor?: number;
+};
+
+// フォローリストレスポンス型
+export type FollowListResponse = {
+  follows: FollowResponse[];
+  pagination: {
+    hasMore: boolean;
+    nextCursor?: string;
+  };
+};
+
+// フォロー状態付きユーザープロフィールレスポンス型
+export type UserProfileWithFollowStatusResponse = UserProfileResponse & {
+  isFollowing: boolean;
+};

--- a/api/src/utils/errors.ts
+++ b/api/src/utils/errors.ts
@@ -69,3 +69,20 @@ export type TweetError = {
   type: TweetErrorType;
   message: string;
 };
+
+// フォローエラータイプ
+export const FollowErrorType = {
+  ALREADY_FOLLOWING: "ALREADY_FOLLOWING",
+  NOT_FOLLOWING: "NOT_FOLLOWING",
+  CANNOT_FOLLOW_SELF: "CANNOT_FOLLOW_SELF",
+  FOLLOW_NOT_FOUND: "FOLLOW_NOT_FOUND",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const satisfies Record<string, string>;
+
+export type FollowErrorType = (typeof FollowErrorType)[keyof typeof FollowErrorType];
+
+// フォローエラー
+export type FollowError = {
+  type: FollowErrorType;
+  message: string;
+};

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -41,6 +41,12 @@ The current development focus is on implementing the core backend functionality 
    - Added user tweets retrieval endpoint and latest tweets retrieval endpoint
    - Created database indexes for optimized tweet queries
    - Implemented comprehensive tests for tweet list retrieval
+   - Implemented Follow model in Prisma schema
+   - Added follow/unfollow functionality with validation
+   - Implemented follow repository, service, and controller
+   - Added follow status checking functionality
+   - Implemented follower/following list retrieval with pagination
+   - Added follow-related endpoints to the API
 
 4. **Code Quality Improvements**
    - Removed unnecessary `else` clauses in `authController.ts` to improve code readability
@@ -93,9 +99,9 @@ The current development focus is on implementing the core backend functionality 
    - Create user search capabilities
 
 3. **Follow Functionality**
-   - Implement follow/unfollow API
-   - Update follower/following counts
-   - Create API for retrieving followers/following lists
+   - ✅ Implement follow/unfollow API
+   - ✅ Update follower/following counts
+   - ✅ Create API for retrieving followers/following lists
 
 ### Medium-term (Next 1-2 Months)
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -50,6 +50,11 @@ The X-Echo project is in the early development phase, with the focus on establis
 - ✅ User tweets retrieval endpoint implemented (with pagination)
 - ✅ Latest tweets retrieval endpoint implemented (with pagination)
 - ✅ Cursor-based pagination for efficient data retrieval
+- ✅ Follow/unfollow API implemented (with authentication)
+- ✅ Follow status validation (already following, not following, cannot follow self)
+- ✅ Follower/following counts update on follow/unfollow
+- ✅ Follower list retrieval endpoint implemented (with pagination)
+- ✅ Following list retrieval endpoint implemented (with pagination)
 
 ### Testing
 - ✅ Testing infrastructure set up with Vitest
@@ -75,7 +80,12 @@ The X-Echo project is in the early development phase, with the focus on establis
 ## What's In Progress
 
 ### Follow Functionality
-- 🔄 Follow/unfollow functionality planning
+- ✅ Follow model defined in Prisma schema
+- ✅ Follow repository implemented
+- ✅ Follow service implemented
+- ✅ Follow controller implemented
+- ✅ Follow/unfollow API endpoints implemented
+- ✅ Follower/following list retrieval endpoints implemented
 
 ## What's Left to Build
 
@@ -84,8 +94,8 @@ The X-Echo project is in the early development phase, with the focus on establis
 
 ### User Interactions
 - ✅ User profile management
-- ❌ Follow/unfollow functionality
-- ❌ Follower/following lists
+- ✅ Follow/unfollow functionality
+- ✅ Follower/following lists
 
 ### Tweet Functionality
 - ✅ Tweet creation
@@ -136,11 +146,11 @@ The X-Echo project is in the early development phase, with the focus on establis
 
 ## Milestones and Targets
 
-### Milestone 1: User Management (In Progress)
+### Milestone 1: User Management (Completed)
 - ✅ User registration
 - ✅ User authentication (login, token refresh, logout)
 - ✅ User profile management
-- Follow functionality
+- ✅ Follow functionality
 
 **Target Completion**: TBD
 


### PR DESCRIPTION
## Changes

- ユーザーをフォローするエンドポイント (POST /:username/follow) を追加
- ユーザーのフォローを解除するエンドポイント (DELETE /:username/follow) を追加
- ユーザーのフォロワーリストを取得するエンドポイント (GET /:username/followers) を追加
- ユーザーがフォローしているユーザーリストを取得するエンドポイント (GET /:username/following) を追加

## Background and Purpose of Changes

- フォロー機能はSNSの基本機能であり、ユーザー間のつながりを作るために必要
- ユーザーが他のユーザーをフォローし、フォロー/フォロワーリストを確認できるようにする

## Test Results

- [x] ルーターの更新を確認
- [ ] 統合テストの実行