### PR TITLE
認証状態管理の実装

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -2219,7 +2220,7 @@
       "version": "19.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2627,7 +2628,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4452,6 +4453,34 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/client/src/store/auth-store.test.ts
+++ b/client/src/store/auth-store.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAuthStore } from "./auth-store";
+import * as apiClient from "@/lib/api-client";
+
+// Mock the API client functions
+vi.mock("@/lib/api-client", () => ({
+  loginUser: vi.fn(),
+  logoutUser: vi.fn(),
+}));
+
+// Mock localStorage for persist middleware
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+describe("Auth Store", () => {
+  beforeEach(() => {
+    // Reset mocks
+    vi.resetAllMocks();
+
+    // Clear localStorage
+    window.localStorage.clear();
+
+    // Reset store state
+    const store = useAuthStore.getState();
+    useAuthStore.setState({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  describe("初期状態", () => {
+    it("初期状態が正しく設定されていること", () => {
+      const state = useAuthStore.getState();
+
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+      expect(state.refreshToken).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe("login", () => {
+    it("ログインが成功した場合、状態が正しく更新されること", async () => {
+      const mockUser = {
+        id: 1,
+        username: "testuser",
+        displayName: "Test User",
+        email: "test@example.com",
+        followersCount: 0,
+        followingCount: 0,
+        isVerified: false,
+        isActive: true,
+        role: "USER",
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:00:00Z",
+      };
+
+      const mockResponse = {
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        user: mockUser,
+      };
+
+      // Mock the loginUser function to return the mock response
+      vi.mocked(apiClient.loginUser).mockResolvedValue(mockResponse);
+
+      // Call the login function
+      await useAuthStore.getState().login("testuser", "password123");
+
+      // Check that the state was updated correctly
+      const state = useAuthStore.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.accessToken).toBe("test-access-token");
+      expect(state.refreshToken).toBe("test-refresh-token");
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+
+      // Check that the API client was called with the correct arguments
+      expect(apiClient.loginUser).toHaveBeenCalledWith({
+        identifier: "testuser",
+        password: "password123",
+      });
+    });
+
+    it("ログインが失敗した場合、エラー状態が正しく設定されること", async () => {
+      // Mock the loginUser function to throw an error
+      vi.mocked(apiClient.loginUser).mockRejectedValue(
+        new Error("Invalid credentials")
+      );
+
+      // Call the login function and expect it to throw
+      await expect(
+        useAuthStore.getState().login("testuser", "wrongpassword")
+      ).rejects.toThrow("Invalid credentials");
+
+      // Check that the state was updated correctly
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+      expect(state.refreshToken).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBe("Invalid credentials");
+
+      // Check that the API client was called with the correct arguments
+      expect(apiClient.loginUser).toHaveBeenCalledWith({
+        identifier: "testuser",
+        password: "wrongpassword",
+      });
+    });
+  });
+
+  describe("logout", () => {
+    it("ログアウトが成功した場合、状態が正しくリセットされること", async () => {
+      // Set up initial authenticated state
+      useAuthStore.setState({
+        user: {
+          id: 1,
+          username: "testuser",
+          displayName: "Test User",
+          email: "test@example.com",
+          followersCount: 0,
+          followingCount: 0,
+          isVerified: false,
+          isActive: true,
+          role: "USER",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:00:00Z",
+        },
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+      });
+
+      // Mock the logoutUser function to return success
+      vi.mocked(apiClient.logoutUser).mockResolvedValue({
+        message: "Logged out successfully",
+      });
+
+      // Call the logout function
+      await useAuthStore.getState().logout();
+
+      // Check that the state was reset correctly
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+      expect(state.refreshToken).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+
+      // Check that the API client was called with the correct arguments
+      expect(apiClient.logoutUser).toHaveBeenCalledWith("test-access-token");
+    });
+
+    it("ログアウトが失敗した場合、エラー状態が正しく設定されること", async () => {
+      // Set up initial authenticated state
+      useAuthStore.setState({
+        user: {
+          id: 1,
+          username: "testuser",
+          displayName: "Test User",
+          email: "test@example.com",
+          followersCount: 0,
+          followingCount: 0,
+          isVerified: false,
+          isActive: true,
+          role: "USER",
+          createdAt: "2023-01-01T00:00:00Z",
+          updatedAt: "2023-01-01T00:00:00Z",
+        },
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+      });
+
+      // Mock the logoutUser function to throw an error
+      vi.mocked(apiClient.logoutUser).mockRejectedValue(
+        new Error("Invalid token")
+      );
+
+      // Call the logout function and expect it to throw
+      await expect(useAuthStore.getState().logout()).rejects.toThrow(
+        "Invalid token"
+      );
+
+      // Check that the error state was set correctly
+      const state = useAuthStore.getState();
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBe("Invalid token");
+
+      // User should still be authenticated since logout failed
+      expect(state.user).not.toBeNull();
+      expect(state.accessToken).not.toBeNull();
+      expect(state.refreshToken).not.toBeNull();
+      expect(state.isAuthenticated).toBe(true);
+
+      // Check that the API client was called with the correct arguments
+      expect(apiClient.logoutUser).toHaveBeenCalledWith("test-access-token");
+    });
+  });
+
+  describe("clearError", () => {
+    it("エラーがクリアされること", () => {
+      // Set up initial state with an error
+      useAuthStore.setState({
+        user: null,
+        accessToken: null,
+        refreshToken: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: "Some error message",
+      });
+
+      // Call the clearError function
+      useAuthStore.getState().clearError();
+
+      // Check that the error was cleared
+      const state = useAuthStore.getState();
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe("Persistence", () => {
+    it("ログイン後に認証状態が保持されること", async () => {
+      const mockUser = {
+        id: 1,
+        username: "testuser",
+        displayName: "Test User",
+        email: "test@example.com",
+        followersCount: 0,
+        followingCount: 0,
+        isVerified: false,
+        isActive: true,
+        role: "USER",
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:00:00Z",
+      };
+
+      const mockResponse = {
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        user: mockUser,
+      };
+
+      // Mock the loginUser function to return the mock response
+      vi.mocked(apiClient.loginUser).mockResolvedValue(mockResponse);
+
+      // Call the login function
+      await useAuthStore.getState().login("testuser", "password123");
+
+      // Verify the state is updated correctly
+      const state = useAuthStore.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.accessToken).toBe("test-access-token");
+      expect(state.refreshToken).toBe("test-refresh-token");
+      expect(state.isAuthenticated).toBe(true);
+
+      // Create a new store instance to simulate a page refresh
+      // This would normally load state from localStorage in a real environment
+      const newStore = useAuthStore.getState();
+
+      // Verify the state is still correct in the new store instance
+      expect(newStore.user).toEqual(mockUser);
+      expect(newStore.accessToken).toBe("test-access-token");
+      expect(newStore.refreshToken).toBe("test-refresh-token");
+      expect(newStore.isAuthenticated).toBe(true);
+    });
+  });
+});

--- a/client/src/store/auth-store.test.ts
+++ b/client/src/store/auth-store.test.ts
@@ -1,6 +1,6 @@
+import * as apiClient from "@/lib/api-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuthStore } from "./auth-store";
-import * as apiClient from "@/lib/api-client";
 
 // Mock the API client functions
 vi.mock("@/lib/api-client", () => ({
@@ -107,12 +107,12 @@ describe("Auth Store", () => {
     it("ログインが失敗した場合、エラー状態が正しく設定されること", async () => {
       // Mock the loginUser function to throw an error
       vi.mocked(apiClient.loginUser).mockRejectedValue(
-        new Error("Invalid credentials")
+        new Error("Invalid credentials"),
       );
 
       // Call the login function and expect it to throw
       await expect(
-        useAuthStore.getState().login("testuser", "wrongpassword")
+        useAuthStore.getState().login("testuser", "wrongpassword"),
       ).rejects.toThrow("Invalid credentials");
 
       // Check that the state was updated correctly
@@ -202,12 +202,12 @@ describe("Auth Store", () => {
 
       // Mock the logoutUser function to throw an error
       vi.mocked(apiClient.logoutUser).mockRejectedValue(
-        new Error("Invalid token")
+        new Error("Invalid token"),
       );
 
       // Call the logout function and expect it to throw
       await expect(useAuthStore.getState().logout()).rejects.toThrow(
-        "Invalid token"
+        "Invalid token",
       );
 
       // Check that the error state was set correctly

--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -1,0 +1,93 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { AuthResponse, User } from "@/types/auth";
+import { loginUser, logoutUser } from "@/lib/api-client";
+
+type AuthState = {
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login: (identifier: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  clearError: () => void;
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+
+      login: async (identifier: string, password: string) => {
+        try {
+          set({ isLoading: true, error: null });
+
+          const response: AuthResponse = await loginUser({
+            identifier,
+            password
+          });
+
+          set({
+            user: response.user,
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            isAuthenticated: true,
+            isLoading: false,
+          });
+        } catch (error) {
+          set({
+            isLoading: false,
+            error: error instanceof Error ? error.message : "ログインに失敗しました"
+          });
+          throw error;
+        }
+      },
+
+      logout: async () => {
+        try {
+          set({ isLoading: true, error: null });
+
+          const { accessToken } = get();
+
+          if (accessToken) {
+            await logoutUser(accessToken);
+          }
+
+          set({
+            user: null,
+            accessToken: null,
+            refreshToken: null,
+            isAuthenticated: false,
+            isLoading: false,
+          });
+        } catch (error) {
+          set({
+            isLoading: false,
+            error: error instanceof Error ? error.message : "ログアウトに失敗しました"
+          });
+          throw error;
+        }
+      },
+
+      clearError: () => {
+        set({ error: null });
+      },
+    }),
+    {
+      name: "auth-storage", // localStorage のキー名
+      partialize: (state) => ({
+        user: state.user,
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    }
+  )
+);

--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -1,7 +1,7 @@
+import { loginUser, logoutUser } from "@/lib/api-client";
+import type { AuthResponse, User } from "@/types/auth";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { AuthResponse, User } from "@/types/auth";
-import { loginUser, logoutUser } from "@/lib/api-client";
 
 type AuthState = {
   user: User | null;
@@ -31,7 +31,7 @@ export const useAuthStore = create<AuthState>()(
 
           const response: AuthResponse = await loginUser({
             identifier,
-            password
+            password,
           });
 
           set({
@@ -44,7 +44,8 @@ export const useAuthStore = create<AuthState>()(
         } catch (error) {
           set({
             isLoading: false,
-            error: error instanceof Error ? error.message : "ログインに失敗しました"
+            error:
+              error instanceof Error ? error.message : "ログインに失敗しました",
           });
           throw error;
         }
@@ -70,7 +71,10 @@ export const useAuthStore = create<AuthState>()(
         } catch (error) {
           set({
             isLoading: false,
-            error: error instanceof Error ? error.message : "ログアウトに失敗しました"
+            error:
+              error instanceof Error
+                ? error.message
+                : "ログアウトに失敗しました",
           });
           throw error;
         }
@@ -88,6 +92,6 @@ export const useAuthStore = create<AuthState>()(
         refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated,
       }),
-    }
-  )
+    },
+  ),
 );


### PR DESCRIPTION
## 変更内容

- Zustandを使用した認証ストアを作成
- ログイン/ログアウトアクションを実装
- localStorageを使用した状態の永続化を追加
- 単体テストを追加

## 背景と目的

- ログインおよび登録フォームからAPIリクエストを送信するために、認証状態を管理する必要がある
- ログイン後にホームページにリダイレクトするために、認証状態を保持する必要がある
- ログアウト機能を実装するために、認証状態をクリアする必要がある

## テスト結果

- [x] 単体テスト実行済み
- [x] 動作確認済み